### PR TITLE
Changes to allow manual start of scheduler.

### DIFF
--- a/src/main/java/org/nnsoft/guice/guartz/QuartzModule.java
+++ b/src/main/java/org/nnsoft/guice/guartz/QuartzModule.java
@@ -103,6 +103,17 @@ public abstract class QuartzModule
     
     /**
      * Allows to configure the scheduler.
+     * 
+     * <pre>
+     * Guice.createInjector(..., new QuartzModule() {
+     *
+     *     {@literal @}Override
+     *     protected void schedule() {
+     *       configureScheduler().withManualStart();
+     *     }
+     *
+     * });
+     * </pre> 
      */
     protected final SchedulerConfigurationBuilder configureScheduler() {
     	return schedulerConfiguration;

--- a/src/main/java/org/nnsoft/guice/guartz/QuartzModule.java
+++ b/src/main/java/org/nnsoft/guice/guartz/QuartzModule.java
@@ -48,6 +48,8 @@ public abstract class QuartzModule
 
     private Multibinder<SchedulerListener> schedulerListeners;
 
+	private SchedulerConfiguration schedulerConfiguration;
+
     /**
      * {@inheritDoc}
      */
@@ -57,22 +59,26 @@ public abstract class QuartzModule
         checkState( jobListeners == null, "Re-entry is not allowed." );
         checkState( triggerListeners == null, "Re-entry is not allowed." );
         checkState( schedulerListeners == null, "Re-entry is not allowed." );
+        checkState( schedulerConfiguration == null, "Re-entry is not allowed." );
 
         jobListeners = newSetBinder( binder(), JobListener.class );
         triggerListeners = newSetBinder( binder(), TriggerListener.class );
         schedulerListeners = newSetBinder( binder(), SchedulerListener.class );
-
+        schedulerConfiguration = new SchedulerConfiguration();
+        
         try
         {
             schedule();
             bind( JobFactory.class ).to( InjectorJobFactory.class ).in( SINGLETON );
             bind( Scheduler.class ).toProvider( SchedulerProvider.class ).asEagerSingleton();
+            bind( SchedulerConfiguration.class ).toInstance(schedulerConfiguration);
         }
         finally
         {
             jobListeners = null;
             triggerListeners = null;
             schedulerListeners = null;
+            schedulerConfiguration = null;
         }
     }
 
@@ -94,6 +100,13 @@ public abstract class QuartzModule
      * @see JobSchedulerBuilder
      */
     protected abstract void schedule();
+    
+    /**
+     * Allows to configure the scheduler.
+     */
+    protected final SchedulerConfigurationBuilder configureScheduler() {
+    	return schedulerConfiguration;
+    }
 
     /**
      * Add the {@code JobListener} binding.

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerConfiguration.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerConfiguration.java
@@ -1,8 +1,11 @@
 package org.nnsoft.guice.guartz;
 
+/**
+ * Configuration of scheduler. 
+ */
 class SchedulerConfiguration implements SchedulerConfigurationBuilder {
 
-	private boolean manualStart;
+	private boolean manualStart = false;
 
 	public SchedulerConfiguration withManualStart() {
 		this.manualStart = true;

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerConfiguration.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerConfiguration.java
@@ -1,0 +1,15 @@
+package org.nnsoft.guice.guartz;
+
+class SchedulerConfiguration implements SchedulerConfigurationBuilder {
+
+	private boolean manualStart;
+
+	public SchedulerConfiguration withManualStart() {
+		this.manualStart = true;
+		return this;
+	}
+	
+	boolean startManually() {
+		return manualStart;
+	}
+}

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerConfigurationBuilder.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerConfigurationBuilder.java
@@ -1,5 +1,8 @@
 package org.nnsoft.guice.guartz;
 
+/**
+ * Contains methods to change scheduler configuration by subclasses of QuartzModule.
+ */
 public interface SchedulerConfigurationBuilder {
 	SchedulerConfiguration withManualStart();
 }

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerConfigurationBuilder.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerConfigurationBuilder.java
@@ -1,0 +1,5 @@
+package org.nnsoft.guice.guartz;
+
+public interface SchedulerConfigurationBuilder {
+	SchedulerConfiguration withManualStart();
+}

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerProvider.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerProvider.java
@@ -46,11 +46,14 @@ final class SchedulerProvider
      *
      * @throws SchedulerException If any error occurs
      */
-    public SchedulerProvider()
+    @Inject
+    public SchedulerProvider(SchedulerConfiguration schedulerConfiguration)
         throws SchedulerException
     {
         this.scheduler = new StdSchedulerFactory().getScheduler();
-        this.scheduler.start();
+        if (!schedulerConfiguration.startManually()) {
+        	this.scheduler.start();
+        }
     }
 
     /**

--- a/src/test/java/org/nnsoft/guice/guartz/ManualStartTestCase.java
+++ b/src/test/java/org/nnsoft/guice/guartz/ManualStartTestCase.java
@@ -1,0 +1,46 @@
+package org.nnsoft.guice.guartz;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.inject.Inject;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.quartz.Scheduler;
+
+import com.google.inject.Guice;
+
+public class ManualStartTestCase {
+
+	@Inject
+	private Scheduler scheduler;
+	
+    @Inject
+    private TimedTask timedTask;
+	
+    @Before
+	public void setUp() {
+		Guice.createInjector(new QuartzModule() {
+			@Override
+			protected void schedule() {
+				configureScheduler().withManualStart();
+				scheduleJob(TimedTask.class);
+			}
+		}).injectMembers(this);
+	}
+	
+    @After
+	public void tearDown() throws Exception {
+		scheduler.shutdown();
+	}
+	
+	@Test
+	public void testManualStart() throws Exception {
+		Thread.sleep(5000L);
+		assertTrue(timedTask.getInvocationsTimedTaskA() == 0);
+		scheduler.start();
+		Thread.sleep(5000L);
+		assertTrue(timedTask.getInvocationsTimedTaskA() > 0);
+	}
+}


### PR DESCRIPTION
If thread is started from Guice, it can cause deadlocks. Quartz scheduler is initializing in another thread, which caused problems in my code. Solution is to allow for manual start of scheduler, after guice is initialized.

Releated discussions:
http://code.google.com/p/google-guice/issues/detail?id=183
http://groups.google.com/group/google-guice/browse_thread/thread/c4ccd95b76192519
