### PR TITLE
Optional support for configuring the Scheduler with custom Properties (i...

### DIFF
--- a/src/main/java/org/nnsoft/guice/guartz/QuartzModule.java
+++ b/src/main/java/org/nnsoft/guice/guartz/QuartzModule.java
@@ -109,7 +109,7 @@ public abstract class QuartzModule
      *
      *     {@literal @}Override
      *     protected void schedule() {
-     *       configureScheduler().withManualStart();
+     *       configureScheduler().withManualStart().withProperties(...);
      *     }
      *
      * });

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerConfiguration.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerConfiguration.java
@@ -16,6 +16,8 @@ package org.nnsoft.guice.guartz;
  *    limitations under the License.
  */
 
+import java.util.Properties;
+
 /**
  * Configuration of scheduler.
  *
@@ -26,10 +28,17 @@ class SchedulerConfiguration
 {
 
     private boolean manualStart = false;
+    private Properties properties;
 
-    public SchedulerConfiguration withManualStart()
+    public SchedulerConfigurationBuilder withManualStart()
     {
         manualStart = true;
+        return this;
+    }
+
+    public SchedulerConfigurationBuilder withProperties(Properties properties)
+    {
+        this.properties = properties;
         return this;
     }
 
@@ -38,4 +47,7 @@ class SchedulerConfiguration
         return manualStart;
     }
 
+    Properties getProperties() {
+        return properties;
+    }
 }

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerConfigurationBuilder.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerConfigurationBuilder.java
@@ -16,6 +16,8 @@ package org.nnsoft.guice.guartz;
  *    limitations under the License.
  */
 
+import java.util.Properties;
+
 /**
  * Contains methods to change scheduler configuration by subclasses of QuartzModule.
  *
@@ -24,6 +26,8 @@ package org.nnsoft.guice.guartz;
 public interface SchedulerConfigurationBuilder
 {
 
-    SchedulerConfiguration withManualStart();
+    SchedulerConfigurationBuilder withManualStart();
+
+    SchedulerConfigurationBuilder withProperties(Properties properties);
 
 }

--- a/src/main/java/org/nnsoft/guice/guartz/SchedulerProvider.java
+++ b/src/main/java/org/nnsoft/guice/guartz/SchedulerProvider.java
@@ -16,18 +16,13 @@ package org.nnsoft.guice.guartz;
  *    limitations under the License.
  */
 
-import java.util.Set;
+import org.quartz.*;
+import org.quartz.impl.StdSchedulerFactory;
+import org.quartz.spi.JobFactory;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-
-import org.quartz.JobListener;
-import org.quartz.Scheduler;
-import org.quartz.SchedulerException;
-import org.quartz.SchedulerListener;
-import org.quartz.TriggerListener;
-import org.quartz.impl.StdSchedulerFactory;
-import org.quartz.spi.JobFactory;
+import java.util.Set;
 
 /**
  * Provides a {@code Scheduler} instance.
@@ -50,7 +45,10 @@ final class SchedulerProvider
     public SchedulerProvider(SchedulerConfiguration schedulerConfiguration)
         throws SchedulerException
     {
-        this.scheduler = new StdSchedulerFactory().getScheduler();
+        StdSchedulerFactory schedulerFactory = new StdSchedulerFactory();
+        if ( schedulerConfiguration.getProperties() != null )
+            schedulerFactory.initialize( schedulerConfiguration.getProperties() );
+        this.scheduler = schedulerFactory.getScheduler();
         if ( !schedulerConfiguration.startManually() )
         {
             scheduler.start();

--- a/src/test/java/org/nnsoft/guice/guartz/WithPropertiesTestCase.java
+++ b/src/test/java/org/nnsoft/guice/guartz/WithPropertiesTestCase.java
@@ -1,0 +1,68 @@
+package org.nnsoft.guice.guartz;
+
+/*
+ *    Copyright 2009-2012 The 99 Software Foundation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import com.google.inject.Guice;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.quartz.Scheduler;
+
+import javax.inject.Inject;
+import java.util.Properties;
+
+import static junit.framework.Assert.assertEquals;
+
+public class WithPropertiesTestCase
+{
+    private static final String INSTANCE_NAME = "Guartz";
+
+    @Inject
+    private Scheduler scheduler;
+
+    @Before
+    public void setUp()
+    {
+        Guice.createInjector( new QuartzModule()
+        {
+            @Override
+            protected void schedule()
+            {
+                Properties properties = new Properties() {{
+                    put("org.quartz.scheduler.instanceName", INSTANCE_NAME);
+                    put("org.quartz.threadPool.class", "org.quartz.simpl.ZeroSizeThreadPool");
+                }};
+                configureScheduler().withProperties(properties);
+            }
+        } ).getMembersInjector( WithPropertiesTestCase.class ).injectMembers( this );
+    }
+
+    @After
+    public void tearDown()
+        throws Exception
+    {
+        scheduler.shutdown();
+    }
+
+    @Test
+    public void testPropertiesConfiguredInstanceName()
+        throws Exception
+    {
+        assertEquals(scheduler.getSchedulerName(), INSTANCE_NAME);
+    }
+
+}


### PR DESCRIPTION
...nstead of using the file-based Quartz .properties location mechanism)

This change extends the SchedulerConfigurationBuilder to allow initializing the Quartz scheduler with custom properties. A new unit test is included.

The change is probably binary-incompatible as I took the chance to fix the SchedulerConfigurationBuilder interface (which should not have a reference to the SchedulerConfiguration class). It should be source-compatible as long as no one was doing and such assignments:

```
SchedulerConfiguration config = configureScheduler().withManualStart();
```
